### PR TITLE
removing trailing comma

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,5 +11,5 @@
 	"release_date": "2016-10-02",
 	"year": "2016",
 	"version": "0.0.0",
-  "license": "Mit",
+  "license": "Mit"
 }


### PR DESCRIPTION
Python's json.loads throws an exception when there are trailing commas.  It looks like the last item of the object was removed in a previous commit, but the trailing comma remained.